### PR TITLE
Fix/create project validation

### DIFF
--- a/dapp/src/components/ConnectWallet.astro
+++ b/dapp/src/components/ConnectWallet.astro
@@ -44,7 +44,6 @@
     setPublicKey,
     disconnect,
   } from "../service/walletService";
-  import { truncateMiddle } from "../utils/utils";
 
   document.addEventListener("astro:page-load", () => {
     initializeConnection();
@@ -53,7 +52,6 @@
     ) as HTMLButtonElement;
 
     async function setLoggedIn(publicKey: string) {
-      const truncatedKey = truncateMiddle(publicKey, 13);
       // Safe DOM manipulation instead of innerHTML
       button.textContent = "";
       const textElement = document.createElement("span");

--- a/dapp/src/components/layout/Navbar.astro
+++ b/dapp/src/components/layout/Navbar.astro
@@ -3,7 +3,7 @@ import ConnectWallet from "../ConnectWallet.astro";
 import JoinCommunityButton from "../JoinCommunityButton.tsx";
 import NavbarSearch from "../NavbarSearch.tsx";
 
-const { page } = Astro.props;
+
 ---
 
 <header role="banner">
@@ -33,12 +33,12 @@ const { page } = Astro.props;
           </div>
         </div>
 
-        <!-- Search bar - takes remaining space -->
+        <!-- Search bar -->
         <div class="flex-1 flex justify-start ml-3 md:ml-4">
-          <NavbarSearch client:load onAddProject={() => {}} />
+          <NavbarSearch client:load _onAddProject={() => {}} />
         </div>
 
-        <!-- Wallet connect and community button on right -->
+        <!-- Wallet connect + community button -->
         <div class="flex items-center gap-4 md:gap-6 flex-shrink-0">
           <div class="ml-6">
             <ConnectWallet />
@@ -53,7 +53,9 @@ const { page } = Astro.props;
 </header>
 
 <script>
-  // Toggle Join Community button visibility
+  // same symbol in <script> scope
+  const GLOBAL_KEY = Symbol.for("globalListenersInited");
+
   const updateJoinButtonVisibility = () => {
     const publicKey = localStorage.getItem("publicKey");
     const wrapper = document.getElementById("join-community-wrapper");
@@ -62,14 +64,12 @@ const { page } = Astro.props;
     }
   };
 
-  // Initialize global event listeners once
   const initGlobalListeners = () => {
-    if (window.globalListenersInited) return;
-    window.globalListenersInited = true;
+    if ((window as any)[GLOBAL_KEY]) return; // ✅ safe check
+    (window as any)[GLOBAL_KEY] = true;
 
     const createProjectEvent = new CustomEvent("create-project-global");
 
-    // Handle create project modal trigger
     document.addEventListener("show-create-project-modal", () => {
       if (window.location.pathname !== "/") {
         sessionStorage.setItem("openCreateProjectModal", "true");
@@ -79,18 +79,16 @@ const { page } = Astro.props;
       }
     });
 
-    // Wallet connection events
     window.addEventListener("walletConnected", updateJoinButtonVisibility);
     window.addEventListener("walletDisconnected", updateJoinButtonVisibility);
   };
 
-  // Run visibility & listeners setup on page load
   document.addEventListener("astro:page-load", () => {
     updateJoinButtonVisibility();
     initGlobalListeners();
   });
 
-  // Run immediately for initial load
+  // immediate run on first load
   updateJoinButtonVisibility();
   initGlobalListeners();
 </script>

--- a/dapp/src/components/page/dashboard/CreateProjectModal.tsx
+++ b/dapp/src/components/page/dashboard/CreateProjectModal.tsx
@@ -1,16 +1,17 @@
 import { getProjectFromName } from "@service/ReadContractService";
+import { loadedPublicKey } from "@service/walletService";
 import {
   setConfigData,
   setProject,
   setProjectRepoInfo,
 } from "@service/StateService";
 import { navigate } from "astro:transitions/client";
-import Button from "components/utils/Button";
-import Input from "components/utils/Input";
-import Label from "components/utils/Label";
-import FlowProgressModal from "components/utils/FlowProgressModal";
-import Step from "components/utils/Step";
-import Title from "components/utils/Title";
+import Button from "components/utils/Button.tsx";
+import Input from "components/utils/Input.tsx";
+import Label from "components/utils/Label.tsx";
+import FlowProgressModal from "components/utils/FlowProgressModal.tsx";
+import Step from "components/utils/Step.tsx";
+import Title from "components/utils/Title.tsx";
 import { useState, type FC, useCallback, useEffect } from "react";
 import { getAuthorRepo } from "utils/editLinkFunctions";
 import { extractConfigData, toast } from "utils/utils";
@@ -18,21 +19,27 @@ import {
   validateProjectName as validateProjectNameUtil,
   validateGithubUrl,
   validateMaintainerAddress,
-} from "utils/validations";
-import Textarea from "components/utils/Textarea";
-import Spinner from "components/utils/Spinner";
+} from "utils/validations.ts";
+import Textarea from "components/utils/Textarea.tsx";
+import Spinner from "components/utils/Spinner.tsx";
 
 // Get domain contract ID from environment with fallback
 const SOROBAN_DOMAIN_CONTRACT_ID =
   import.meta.env.PUBLIC_SOROBAN_DOMAIN_CONTRACT_ID ||
   "CAQWEZNN5X7LFD6PZBQXALVH4LSJW2KGNDMFJBQ3DWHXUVQ2JIZ6AQU6"; // Fallback value
 
+// Define ModalProps type for the modal component
+type ModalProps = {
+  onClose: () => void;
+};
+
 const CreateProjectModal: FC<ModalProps> = ({ onClose }) => {
   const [step, setStep] = useState(1);
   const [projectName, setProjectName] = useState("");
   const [maintainerAddresses, setMaintainerAddresses] = useState<string[]>([
-    "",
+    loadedPublicKey() || "",
   ]);
+
   const [maintainerGithubs, setMaintainerGithubs] = useState<string[]>([""]);
   const [githubRepoUrl, setGithubRepoUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -552,7 +559,9 @@ ${maintainerGithubs.map((gh) => `[[PRINCIPALS]]\ngithub="${gh}"`).join("\n\n")}
                         <Input
                           className="flex-1"
                           value={address}
-                          {...(i == 0 && { label: "Maintainer Address" })}
+                          {...(i == 0 && {
+                            label: "Maintainer Wallet Address",
+                          })}
                           placeholder="G..."
                           onChange={(e) => {
                             setMaintainerAddresses(

--- a/dapp/src/components/page/dashboard/CreateProjectModal.tsx
+++ b/dapp/src/components/page/dashboard/CreateProjectModal.tsx
@@ -555,7 +555,7 @@ ${maintainerGithubs.map((gh) => `[[PRINCIPALS]]\ngithub="${gh}"`).join("\n\n")}
                 <div className="flex flex-col gap-[18px]">
                   {maintainerAddresses.map((address, i) => (
                     <div key={i} className="flex flex-col gap-2 w-full">
-                      <div className="flex gap-[18px]">
+                      <div className="flex flex-col md:flex-row gap-[18px]">
                         <Input
                           className="flex-1"
                           value={address}

--- a/dapp/src/schemas/validation.ts
+++ b/dapp/src/schemas/validation.ts
@@ -138,7 +138,7 @@ export function validateField<T>(
     return null;
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return error.errors[0]?.message || "Validation failed";
+      return error.issues[0]?.message || "Validation failed";
     }
     return "Validation failed";
   }
@@ -151,10 +151,10 @@ export function validateObject<T>(
   try {
     schema.parse(obj);
     return { isValid: true, errors: {} };
-  } catch {
+  } catch (error) {
     if (error instanceof z.ZodError) {
       const errors: Record<string, string> = {};
-      error.errors.forEach((err) => {
+      error.issues.forEach((err) => {
         const path = err.path.join(".");
         errors[path] = err.message;
       });

--- a/dapp/tsconfig.json
+++ b/dapp/tsconfig.json
@@ -5,7 +5,7 @@
     "paths": {
       "@service/*": ["service/*"]
     },
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": true
   },
   "extends": "astro/tsconfigs/strictest",
   "exclude": ["packages"]


### PR DESCRIPTION
This PR addresses an issue in validation.ts that prevented the CreateProjectModal from progressing past the "Build your team" step.
Changes Made:
- Fixed validation logic to allow the modal to continue past the "Build your team" stage.
- Updated the flow so the maintainer's wallet field is automatically prefilled with the user's wallet address.

