### PR TITLE
Added option fee-less transactions using launchtube

### DIFF
--- a/dapp/.env.example
+++ b/dapp/.env.example
@@ -12,3 +12,8 @@ PUBLIC_DEFAULT_TIMEOUT=30
 
 STORACHA_SING_PRIVATE_KEY=""
 STORACHA_PROOF=""
+
+# Set to "true" to enable Launchtube for transaction submission
+PUBLIC_USE_LAUNCHTUBE="true"
+# Your Launchtube JWT token (get from https://testnet.launchtube.xyz/gen)
+PUBLIC_LAUNCHTUBE_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkYjI1OTExYmQxYmYzZTMzNGY0ZDdkMWQxMzdlNWI3OGZmY2NjZWJkMTA5ZjU3Y2Q0ZGM5ODJmMzk4ZGNkNGRkIiwiZXhwIjoxNzY2NDQ2MjQ3LCJjcmVkaXRzIjoxMDAwMDAwMDAwLCJpYXQiOjE3NTkxODg2NDd9.2TBH6VxCf4fANKdpSbOnBCEGXpPWSuSxFcdqsJuWz_I"

--- a/dapp/src/service/LaunchtubeService.ts
+++ b/dapp/src/service/LaunchtubeService.ts
@@ -1,0 +1,88 @@
+/**
+ * Launchtube Service - Submit Soroban transactions via Launchtube API
+ */
+
+import { retryAsync } from "../utils/retry";
+import { parseContractError } from "../utils/contractErrors";
+
+const LAUNCHTUBE_URL = "https://testnet.launchtube.xyz";
+
+/**
+ * Check if Launchtube is enabled and configured
+ */
+export function isLaunchtubeEnabled(): boolean {
+  return (
+    import.meta.env.PUBLIC_USE_LAUNCHTUBE === "true" &&
+    !!import.meta.env.PUBLIC_LAUNCHTUBE_TOKEN
+  );
+}
+
+/**
+ * Submit a signed Soroban transaction via Launchtube
+ */
+export async function submitViaLaunchtube(signedTxXdr: string): Promise<any> {
+  if (!isLaunchtubeEnabled()) {
+    throw new Error("Launchtube is not enabled");
+  }
+
+  const response = await retryAsync(async () => {
+    const res = await fetch(LAUNCHTUBE_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${import.meta.env.PUBLIC_LAUNCHTUBE_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ xdr: signedTxXdr }),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new Error(`Launchtube failed: ${errorText}`);
+    }
+
+    return res.json();
+  });
+
+  // Handle contract errors
+  if (response.error) {
+    const errorStr = JSON.stringify(response.error);
+    const contractErrorMatch = errorStr.match(/Error\(Contract, #(\d+)\)/);
+    if (contractErrorMatch) {
+      throw new Error(parseContractError({ message: errorStr } as any));
+    }
+    throw new Error(`Transaction failed: ${errorStr}`);
+  }
+
+  // Process return value
+  if (response.returnValue !== undefined) {
+    try {
+      if (
+        typeof response.returnValue === "number" ||
+        typeof response.returnValue === "boolean"
+      ) {
+        return response.returnValue;
+      }
+
+      const { xdr, scValToNative } = await import("@stellar/stellar-sdk");
+      let decoded: any;
+
+      if (typeof response.returnValue === "string") {
+        const scVal = xdr.ScVal.fromXDR(response.returnValue, "base64");
+        decoded = scValToNative(scVal);
+      } else {
+        decoded = scValToNative(response.returnValue);
+      }
+
+      if (typeof decoded === "bigint") return Number(decoded);
+      if (typeof decoded === "number") return decoded;
+      if (typeof decoded === "boolean") return decoded;
+
+      const coerced = Number(decoded);
+      return isNaN(coerced) ? decoded : coerced;
+    } catch {
+      return true;
+    }
+  }
+
+  return response;
+}

--- a/dapp/src/service/TxService.ts
+++ b/dapp/src/service/TxService.ts
@@ -3,14 +3,24 @@ import { parseContractError } from "../utils/contractErrors";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { toast } from "utils/utils";
 import { loadedPublicKey } from "./walletService";
+import { isLaunchtubeEnabled, submitViaLaunchtube } from "./LaunchtubeService";
 
 /**
  * Send a signed transaction (Soroban) and decode typical return values.
+ * - Uses Launchtube if enabled and configured
  * - Accepts base64 XDR directly (soroban-rpc supports it)
  * - Falls back to classic Transaction envelope when necessary
  * - Waits for PENDING → SUCCESS/FAILED and attempts returnValue decoding
  */
 export async function sendSignedTransaction(signedTxXdr: string): Promise<any> {
+  // Try Launchtube first if enabled
+  if (isLaunchtubeEnabled()) {
+    try {
+      return await submitViaLaunchtube(signedTxXdr);
+    } catch (error: any) {
+      console.warn("Launchtube failed, falling back to RPC:", error.message);
+    }
+  }
   const { Transaction, rpc } = await import("@stellar/stellar-sdk");
   const server = new rpc.Server(import.meta.env.PUBLIC_SOROBAN_RPC_URL);
 


### PR DESCRIPTION
This PR added option to create transaction where the fees are sponsored using the launch tube API.

This currently integrates with testnet.

Closes #201 