### PR TITLE
fix(navbar): restore Add Project modal trigger using direct event dispatch

### DIFF
--- a/dapp/src/components/NavbarSearch.tsx
+++ b/dapp/src/components/NavbarSearch.tsx
@@ -4,14 +4,10 @@ import Button from "./utils/Button";
 import { loadedPublicKey } from "../service/walletService";
 import { toast } from "../utils/utils";
 
-interface NavbarSearchProps {
-  _onAddProject: () => void;
-}
-
 // Constants for URL handling
 const HOME_PATH = "/";
 
-const NavbarSearch = ({ _onAddProject }: NavbarSearchProps) => {
+const NavbarSearch = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [originalUrl, setOriginalUrl] = useState("");
@@ -152,7 +148,7 @@ const NavbarSearch = ({ _onAddProject }: NavbarSearchProps) => {
       return;
     }
 
-    _onAddProject();
+    document.dispatchEvent(new CustomEvent("show-create-project-modal"));
   };
 
   const handleClearSearch = () => {

--- a/dapp/src/components/layout/Navbar.astro
+++ b/dapp/src/components/layout/Navbar.astro
@@ -33,14 +33,7 @@ import NavbarSearch from "../NavbarSearch.tsx";
 
         <!-- Search bar -->
         <div class="flex-1 flex justify-start ml-3 md:ml-4">
-          <NavbarSearch
-            client:load
-            _onAddProject={() => {
-              document.dispatchEvent(
-                new CustomEvent("show-create-project-modal"),
-              );
-            }}
-          />
+          <NavbarSearch client:load />
         </div>
 
         <!-- Wallet connect + community button -->


### PR DESCRIPTION
**This PR restores the functionality of the Add Project button, which had stopped opening the project creation modal.**

## Key updates include: 
- Re-enabled the modal trigger by dispatching the show-create-project-modal event directly from NavbarSearch.
- Removed the now-unused _onAddProject variable for cleaner and more maintainable code.