### PR TITLE
feat: Store SBOM

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,72 @@
+name: Generate SPDX and CycloneDX SBOM
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-sbom:
+    name: Generate SPDX and CycloneDX SBOM with Trivy
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    environment:
+      name: sbom-ipfs
+    
+    steps:
+      - name: Install dependencies
+        run: |
+          apk add --no-cache curl wget git
+      
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      
+      - name: Install Trivy
+        run: |
+          wget -qO - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+      
+      - name: Generate SBOMs
+        run: |
+          trivy fs --format spdx-json --output sbom.spdx.json .
+          trivy fs --format cyclonedx --output sbom.cyclonedx.json .
+      
+      - name: Upload SBOMs as artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: sbom-${{ github.ref_name }}
+          path: |
+            sbom.spdx.json
+            sbom.cyclonedx.json
+          retention-days: 90
+      
+      - name: Create SBOM directory for IPFS upload
+        run: |
+          mkdir -p sbom-release
+          cp sbom.spdx.json sbom-release/
+          cp sbom.cyclonedx.json sbom-release/
+      
+      - name: Upload SBOMs to IPFS
+        uses: storacha/add-to-web3@892505d8e70c79336721485e5500155c17a728e0
+        id: storacha
+        with:
+          path_to_add: "sbom-release"
+          secret_key: ${{ secrets.STORACHA_PRINCIPAL }}
+          proof: ${{ secrets.STORACHA_PROOF }}
+      
+      - name: Job summary
+        run: |
+          echo "### SBOMs uploaded to IPFS! :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Release: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CID: ${{ steps.storacha.outputs.cid }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: ${{ steps.storacha.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Formats: SPDX JSON, CycloneDX JSON" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This Pull Request is the first step to close #175 . The goal is to highlight how SBOMs can be easily created via the CI/CD and can be uploaded. In order to show this, I added a workflow called sbom.yml which generates a set of 2 SBOMs, one for each current format (SPDX, CycloneDX). 

Sidenote: I opted to use alpine:latest instead of directly going with the ubuntu runners, as it is more lightweight and has therefore less dependencies. I am still considering if moving away from :latest and doing a proper version pin is better, if we already go the extra mile to use a more lightweight container. 