### PR TITLE
fix(ui): add top margin to join modal close button

### DIFF
--- a/dapp/src/components/utils/Modal.tsx
+++ b/dapp/src/components/utils/Modal.tsx
@@ -71,7 +71,7 @@ const Modal: FC<ModalProps> = ({
 
   return (
     <div
-      className="fixed inset-0 bg-white/35 backdrop-blur-md flex justify-center items-center z-[2] p-2 sm:p-4"
+      className="fixed inset-0 bg-white/35 backdrop-blur-md flex justify-center items-center z-[2] p-2 sm:p-4 mt-4"
       onClick={handleBackdropClick}
       data-modal-container
     >


### PR DESCRIPTION
This PR improves the usability of the Join modal by adding top spacing to the close button.

closes #400 