### PR TITLE
feat: Add Git identity binding during member registration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "soroban-versioning",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/contracts/tansu/src/errors.rs
+++ b/contracts/tansu/src/errors.rs
@@ -39,4 +39,8 @@ pub enum ContractErrors {
     // Versioning
     NoProjectPageFound = 26,
     TooManySubProjects = 27,
+    // Git identity binding
+    GitIdentityVerificationFailed = 28,
+    GitIdentityInvalidMessage = 29,
+    GitIdentityMessageParsing = 30,
 }

--- a/contracts/tansu/src/lib.rs
+++ b/contracts/tansu/src/lib.rs
@@ -56,9 +56,19 @@ pub trait TansuTrait {
 }
 
 pub trait MembershipTrait {
-    fn add_member(env: Env, member_address: Address, meta: String);
+    fn add_member(
+        env: Env,
+        member_address: Address,
+        meta: String,
+        git_identity: Option<String>,
+        git_pubkey: Option<BytesN<32>>,
+        msg: Option<Bytes>,
+        sig: Option<BytesN<64>>,
+    );
 
     fn get_member(env: Env, member_address: Address) -> types::Member;
+
+    fn get_git_identity(env: Env, member_address: Address) -> Option<types::GitIdentity>;
 
     fn set_badges(
         env: Env,

--- a/contracts/tansu/src/types.rs
+++ b/contracts/tansu/src/types.rs
@@ -19,6 +19,7 @@ pub enum ContractKey {
 #[contracttype]
 pub enum DataKey {
     Member(Address), // Member of the DAO, address
+    GitIdentity(Address), // Verified Git identity binding for a member
     Paused,          // Contract pause state
     UpgradeProposal, // Pending upgrade proposal
     AdminsConfig,    // Admin configuration for upgrades and other admin operations
@@ -55,6 +56,16 @@ pub struct ProjectBadges {
 pub struct Member {
     pub projects: Vec<ProjectBadges>,
     pub meta: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GitIdentity {
+    pub git_identity: String, // "<provider>:<username>"
+    pub git_pubkey: BytesN<32>,
+    pub msg: Bytes,
+    pub sig: BytesN<64>,
+    pub signed_at: u64,
 }
 
 #[contracttype]

--- a/dapp/src/components/page/dashboard/JoinCommunityModal.tsx
+++ b/dapp/src/components/page/dashboard/JoinCommunityModal.tsx
@@ -6,6 +6,8 @@ import { loadedPublicKey } from "@service/walletService";
 import { toast } from "utils/utils";
 import { validateStellarAddress, validateUrl } from "utils/validations";
 import SimpleMarkdownEditor from "components/utils/SimpleMarkdownEditor";
+import { ed25519 } from "@noble/curves/ed25519";
+import { Buffer } from "buffer";
 
 interface ProfileImageFile {
   localUrl: string;
@@ -26,7 +28,6 @@ const JoinCommunityModal: FC<{
   const [profileImage, setProfileImage] = useState<ProfileImageFile | null>(
     null,
   );
-  // const [isDropped,setIsDropped]=useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
@@ -39,71 +40,147 @@ const JoinCommunityModal: FC<{
   const [socialError, setSocialError] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
 
+  // Git identity binding state
+  const [linkGitHandle, setLinkGitHandle] = useState(false);
+  const [gitHandle, setGitHandle] = useState("");
+  const [gitPublicKey, setGitPublicKey] = useState("");
+  const [gitSignature, setGitSignature] = useState("");
+  const [challengeMessage, setChallengeMessage] = useState("");
+  const [gitHandleError, setGitHandleError] = useState<string | null>(null);
+  const [gitPublicKeyError, setGitPublicKeyError] = useState<string | null>(
+    null,
+  );
+  const [isGitPublicKeyVerified, setIsGitPublicKeyVerified] = useState(false);
+
   useEffect(() => {
     if (prefillAddress) {
       setAddress(prefillAddress);
     }
   }, [prefillAddress]);
 
+  useEffect(() => {
+    if (linkGitHandle && gitHandle && address) {
+      const networkPassphrase =
+        import.meta.env.PUBLIC_SOROBAN_NETWORK_PASSPHRASE;
+      const contractId = import.meta.env.PUBLIC_TANSU_CONTRACT_ID;
+      const nonce = window.crypto.getRandomValues(new Uint8Array(16));
+      const nonceHex = Array.from(nonce)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      const message = `Stellar Signed Message
+${networkPassphrase}
+${address}
+${nonceHex}
+tansu-bind|${contractId}|${gitHandle}`;
+      setChallengeMessage(message);
+    } else {
+      setChallengeMessage("");
+    }
+  }, [linkGitHandle, gitHandle, address]);
+
+  const fetchGitPublicKey = async () => {
+    if (!gitHandle) {
+      setGitHandleError("Git handle is required");
+      return;
+    }
+    const parts = gitHandle.split(":");
+    if (parts.length !== 2) {
+      setGitHandleError("Invalid format. Use <provider>:<username>");
+      return;
+    }
+    const [provider, username] = parts;
+    if (provider !== "github") {
+      setGitHandleError("Only github is supported for now.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`https://github.com/${username}.keys`);
+      if (response.ok) {
+        const keys = await response.text();
+        const ed25519Key = keys
+          .split("\n")
+          .find((key) => key.startsWith("ssh-ed25519"));
+        if (ed25519Key) {
+          const keyParts = ed25519Key.split(" ");
+          setGitPublicKey(keyParts[1]);
+        } else {
+          setGitPublicKeyError("No Ed25519 key found on GitHub.");
+        }
+      } else {
+        setGitPublicKeyError("Could not fetch keys from GitHub.");
+      }
+    } catch (e) {
+      setGitPublicKeyError("Failed to fetch keys.");
+    }
+  };
+
+  const verifySignature = () => {
+    try {
+      const pubKeyBytes = Buffer.from(gitPublicKey, "base64");
+      const signatureBytes = Buffer.from(gitSignature, "base64");
+      const messageBytes = Buffer.from(challengeMessage, "utf8");
+
+      const verified = ed25519.verify(signatureBytes, messageBytes, pubKeyBytes);
+      setIsGitPublicKeyVerified(verified);
+      if (!verified) {
+        toast.error("Error", "Signature verification failed.");
+      } else {
+        toast.success("Success", "Git public key verified.");
+      }
+    } catch (e) {
+      toast.error("Error", "An error occurred during verification.");
+      setIsGitPublicKeyVerified(false);
+    }
+  };
+
   const handleClose = () => {
-    // Reload page if joining was successful to show fresh data
     if (updateSuccessful) {
       window.location.reload();
     }
-
-    // Reset all states when closing
     setUpdateSuccessful(false);
     setStep(0);
     setIsLoading(false);
     setIsUploading(false);
-
     onClose?.();
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     setImageError(null);
-
     const file = e.target.files?.[0];
     if (file) {
-      // Check if it's PNG or JPG
-      const allowedTypes = ["image/png", "image/jpeg", "image/jpg"];
-      if (!allowedTypes.includes(file.type)) {
+      if (!["image/png", "image/jpeg", "image/jpg"].includes(file.type)) {
         setImageError("Please upload a PNG or JPG image");
         return;
       }
-
-      // Check file size (limit to 5MB)
       if (file.size > 5 * 1024 * 1024) {
         setImageError("Please upload an image smaller than 5MB");
         return;
       }
-
       const url = URL.createObjectURL(file);
       setProfileImage({ localUrl: url, source: file });
     }
   };
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(true);
   };
+
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-
     setImageError(null);
-
     const file = e.dataTransfer.files?.[0];
     if (file) {
-      const allowedTypes = ["image/png", "image/jpeg", "image/jpg"];
-      if (!allowedTypes.includes(file.type)) {
+      if (!["image/png", "image/jpeg", "image/jpg"].includes(file.type)) {
         setImageError("Please upload a PNG or JPG image");
         return;
       }
-
       if (file.size > 5 * 1024 * 1024) {
         setImageError("Please upload an image smaller than 5MB");
         return;
       }
-
       const url = URL.createObjectURL(file);
       setProfileImage({ localUrl: url, source: file });
     }
@@ -116,9 +193,8 @@ const JoinCommunityModal: FC<{
     }
   };
 
-  const hasProfileData = () => {
-    return name.trim() || social.trim() || description.trim() || profileImage;
-  };
+  const hasProfileData = () =>
+    name.trim() || social.trim() || description.trim() || profileImage;
 
   const validateAddressField = (): boolean => {
     const error = validateStellarAddress(address);
@@ -133,10 +209,24 @@ const JoinCommunityModal: FC<{
   };
 
   const validateForm = (): boolean => {
-    const isAddressValid = validateAddressField();
-    const isSocialValid = validateSocialField();
-
-    return isAddressValid && isSocialValid;
+    let isValid = true;
+    if (!validateAddressField()) isValid = false;
+    if (!validateSocialField()) isValid = false;
+    if (linkGitHandle) {
+      if (!gitHandle) {
+        setGitHandleError("Git handle is required.");
+        isValid = false;
+      }
+      if (!gitPublicKey) {
+        setGitPublicKeyError("Public key is required.");
+        isValid = false;
+      }
+      if (!isGitPublicKeyVerified) {
+        toast.error("Error", "Git public key must be verified.");
+        isValid = false;
+      }
+    }
+    return isValid;
   };
 
   const handleJoin = async () => {
@@ -147,46 +237,34 @@ const JoinCommunityModal: FC<{
     try {
       setIsLoading(true);
       setStep(6);
+      const { joinCommunityFlow } = await import("@service/FlowService");
+      let gitIdentityPayload = {};
+      if (linkGitHandle && isGitPublicKeyVerified) {
+        gitIdentityPayload = {
+          git_identity: gitHandle,
+          git_pubkey: Buffer.from(gitPublicKey, "base64"),
+          msg: Buffer.from(challengeMessage, "utf8"),
+          sig: Buffer.from(gitSignature, "base64"),
+        };
+      }
 
-      // Check if user has provided any profile data
       if (!hasProfileData()) {
-        // No profile data, use the new flow with empty files
-        const { joinCommunityFlow } = await import("@service/FlowService");
         await joinCommunityFlow({
           memberAddress: address,
           profileFiles: [],
           onProgress: setStep,
+          ...gitIdentityPayload,
         });
-
-        toast.success("Success", "You have successfully joined the community!");
-        onJoined?.();
-        setUpdateSuccessful(true);
-        setIsLoading(false);
-        setIsUploading(false);
-        setStep(0); // Reset step to show success screen
-        // Don't close modal immediately - let user close it manually
-        return;
-      }
-
-      // User has profile data, prepare files for IPFS
-      setIsUploading(true);
-
-      try {
-        // Create profile data JSON
+      } else {
         const profileData = {
           name: name.trim(),
           description: description.trim(),
           social: social.trim(),
         };
-
         const profileBlob = new Blob([JSON.stringify(profileData)], {
           type: "application/json",
         });
-
-        // Create files array
         const files = [new File([profileBlob], "profile.json")];
-
-        // Add image if provided
         if (profileImage) {
           files.push(
             new File(
@@ -195,31 +273,24 @@ const JoinCommunityModal: FC<{
             ),
           );
         }
-
-        // Use the new Flow 2
-        const { joinCommunityFlow } = await import("@service/FlowService");
         await joinCommunityFlow({
           memberAddress: address,
           profileFiles: files,
           onProgress: setStep,
+          ...gitIdentityPayload,
         });
-
-        toast.success("Success", "You have successfully joined the community!");
-        onJoined?.();
-        setUpdateSuccessful(true);
-        setIsLoading(false);
-        setIsUploading(false);
-        setStep(0); // Reset step to show success screen
-        // Don't close modal immediately - let user close it manually
-      } catch (ipfsError: any) {
-        console.error("IPFS upload error:", ipfsError);
-        setIsUploading(false);
-        throw ipfsError;
       }
+
+      toast.success("Success", "You have successfully joined the community!");
+      onJoined?.();
+      setUpdateSuccessful(true);
+      setIsLoading(false);
+      setIsUploading(false);
+      setStep(0);
     } catch (err: any) {
       console.error("Join community error:", err);
       setError(err.message || "Something went wrong");
-      setStep(0); // Reset step on error
+      setStep(0);
     } finally {
       setIsLoading(false);
       setIsUploading(false);
@@ -310,11 +381,17 @@ const JoinCommunityModal: FC<{
                     onDragOver={handleDragOver}
                     onDrop={handleDrop}
                     onDragLeave={() => setIsDragging(false)}
-                    className={`flex flex-col items-center justify-center w-full h-32 border-2 ${imageError ? "border-red-500" : "border-dashed border-[#978AA1]"} ${isDragging ? "bg-zinc-500" : "bg-white"} cursor-pointer bg-zinc-50 hover:bg-zinc-400`}
+                    className={`flex flex-col items-center justify-center w-full h-32 border-2 ${
+                      imageError ? "border-red-500" : "border-dashed border-[#978AA1]"
+                    } ${
+                      isDragging ? "bg-zinc-500" : "bg-white"
+                    } cursor-pointer bg-zinc-50 hover:bg-zinc-400`}
                   >
                     <div className="flex flex-col items-center justify-center pt-5 pb-6">
                       <svg
-                        className={`w-8 h-8 mb-4 ${imageError ? "text-red-500" : "text-secondary"}`}
+                        className={`w-8 h-8 mb-4 ${
+                          imageError ? "text-red-500" : "text-secondary"
+                        }`}
                         aria-hidden="true"
                         xmlns="http://www.w3.org/2000/svg"
                         fill="none"
@@ -329,16 +406,14 @@ const JoinCommunityModal: FC<{
                         />
                       </svg>
                       <p className="mb-2 text-sm text-secondary">
-                        <span className="font-semibold">Click to upload</span>{" "}
-                        or drag and drop
+                        <span className="font-semibold">Click to upload</span> or
+                        drag and drop
                       </p>
                       <p className="text-xs text-secondary">
                         PNG or JPG (MAX. 5MB)
                       </p>
                       {imageError && (
-                        <p className="mt-2 text-sm text-red-500">
-                          {imageError}
-                        </p>
+                        <p className="mt-2 text-sm text-red-500">{imageError}</p>
                       )}
                     </div>
                     <input
@@ -361,6 +436,89 @@ const JoinCommunityModal: FC<{
                   />
                 </div>
               </div>
+
+              {/* Git Identity Binding Section */}
+              <div className="flex flex-col gap-4 pt-4">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="link-git-handle"
+                    checked={linkGitHandle}
+                    onChange={(e) => setLinkGitHandle(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <label
+                    htmlFor="link-git-handle"
+                    className="text-base font-medium text-primary"
+                  >
+                    Link Git Handle (Optional)
+                  </label>
+                </div>
+
+                {linkGitHandle && (
+                  <div className="flex flex-col gap-4 pl-6 border-l-2 border-gray-200">
+                    <Input
+                      label="Git Handle"
+                      placeholder="<provider>:<username> (e.g., github:alice)"
+                      value={gitHandle}
+                      onChange={(e) => {
+                        setGitHandle(e.target.value);
+                        setGitHandleError(null);
+                      }}
+                      error={gitHandleError}
+                    />
+                    <div className="flex items-end gap-2">
+                      <Input
+                        label="Ed25519 Public Key"
+                        placeholder="Paste your public key or fetch it"
+                        value={gitPublicKey}
+                        onChange={(e) => {
+                          setGitPublicKey(e.target.value);
+                          setGitPublicKeyError(null);
+                        }}
+                        error={gitPublicKeyError}
+                        containerClassName="grow"
+                      />
+                      <Button onClick={fetchGitPublicKey} type="secondary">
+                        Fetch
+                      </Button>
+                    </div>
+
+                    {challengeMessage && (
+                      <>
+                        <div className="flex flex-col gap-2">
+                          <label className="text-base font-medium text-primary">
+                            Challenge Message
+                          </label>
+                          <textarea
+                            readOnly
+                            value={challengeMessage}
+                            className="w-full p-2 border border-gray-300 rounded-md bg-gray-50"
+                            rows={6}
+                          />
+                          <p className="text-xs text-gray-500">
+                            Run the following command in your terminal to sign this
+                            message with your SSH key:
+                          </p>
+                          <code className="text-xs bg-gray-100 p-2 rounded-md overflow-x-auto">
+                            ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n
+                            file &lt;(echo -n "{challengeMessage}")
+                          </code>
+                        </div>
+                        <Input
+                          label="Signature"
+                          placeholder="Paste the signature here"
+                          value={gitSignature}
+                          onChange={(e) => setGitSignature(e.target.value)}
+                        />
+                        <Button onClick={verifySignature} type="secondary" disabled={isGitPublicKeyVerified}>
+                          {isGitPublicKeyVerified ? "Verified" : "Verify"}
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 
@@ -368,7 +526,10 @@ const JoinCommunityModal: FC<{
             <Button type="secondary" onClick={onClose}>
               Cancel
             </Button>
-            <Button isLoading={isLoading || isUploading} onClick={handleJoin}>
+            <Button
+              isLoading={isLoading || isUploading}
+              onClick={handleJoin}
+            >
               Join
             </Button>
           </div>

--- a/dapp/src/service/ReadContractService.ts
+++ b/dapp/src/service/ReadContractService.ts
@@ -216,6 +216,26 @@ async function getMember(memberAddress: string): Promise<Member | null> {
   }
 }
 
+async function getGitIdentity(
+  memberAddress: string,
+): Promise<GitIdentity | null> {
+  if (!memberAddress || memberAddress.trim() === "") {
+    return null;
+  }
+
+  try {
+    const res = await Tansu.get_git_identity({
+      member_address: memberAddress,
+    });
+
+    checkSimulationError(res);
+
+    return res.result;
+  } catch {
+    return null;
+  }
+}
+
 async function getBadges(): Promise<Badges | null> {
   const projectId = loadedProjectId();
   if (projectId === undefined) {
@@ -262,6 +282,7 @@ export {
   getProposals,
   getProposal,
   getMember,
+  getGitIdentity,
   getBadges,
   getProjectsPage,
 };

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello via Bun!");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "soroban-versioning",
+  "module": "index.ts",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Add Git identity binding during member registration

This PR introduces an optional Git identity linking flow during member registration.

Users can now link a Git handle (`github:<username>` or `gitlab:<username>`) to their profile and prove ownership of the account using an Ed25519 signature that follows the SEP-53 signed message format.

### What this adds

* Optional Git handle linking step in the member registration flow
* Fetch or paste Git account public key
* SEP-53 compliant challenge message generation
* Client-side verification of Git signature
* Single wallet transaction for both registration and Git binding
* On-chain validation inside `add_member`
* Verified Git badge on member profile

### Verification flow

1. User provides Git handle
2. Dapp generates a SEP-53 envelope challenge
3. User signs the message using their Git SSH/GPG key
4. Signature is verified in the UI
5. Wallet signs the transaction once
6. Contract verifies:

   * Ed25519 signature
   * network passphrase
   * invoker address
   * nonce format
   * `tansu-bind` payload prefix

If verification succeeds, the contract stores:
`git_identity`, `git_pubkey`, `msg`, `sig`, and `signed_at`.

### UX Impact

* Git linking remains fully optional
* Registration still requires only one wallet approval
* Git ownership proof and member registration occur in a single Soroban transaction

Closes #217
